### PR TITLE
Changed getDistanceTest to compare the absoulte value

### DIFF
--- a/PacMan/Tests/tst_Ghost.cpp
+++ b/PacMan/Tests/tst_Ghost.cpp
@@ -29,8 +29,8 @@ void GhostTest::getDistanceTest()
     QFETCH(QPoint, field2);
     QFETCH(float, distance);
 
-    //The Output value is a float thus a diffrence up to 0.1 is accepted
-    QCOMPARE_LE(Ghost::getDistance(field1,field2) - distance,0.01f);
+    //The Output value is a float thus a absolute diffrence up to 0.1 is accepted
+    QCOMPARE_LE(abs(Ghost::getDistance(field1,field2) - distance),0.01f);
 }
 
 QTEST_APPLESS_MAIN(GhostTest)


### PR DESCRIPTION
Thre prior implementation would have accepted a diffrence from -1 because it's lower than 0.1. With the absolut value this is no longer the case.